### PR TITLE
Optimize(client/superjump.lua): Wrapped in IsPedJumping

### DIFF
--- a/modules/client/coroutine/superjump.lua
+++ b/modules/client/coroutine/superjump.lua
@@ -4,39 +4,41 @@ end
 
 local ped = nil
 
-Citizen.CreateThread(function()
+CreateThread(function()
     while true do
-        Citizen.Wait(500)
+        Wait(500)
         ped = PlayerPedId()
     end
 end)
 
-Citizen.CreateThread(function()
-	while not Util.IsPlayerSpawned() do
-		Citizen.Wait(500)
+CreateThread(function()
+    while not Util.IsPlayerSpawned() do
+		Wait(500)
 	end
-	while true do
-		Citizen.Wait(100)
+    while true do
+        Wait(100)
 
         if IsPedDoingBeastJump(ped) then
             TriggerServerEvent("icarus:417szjzm1goy", "Superjump [C1]", false, {beastJump = true})
             return
         end
 
-        local startPos = GetEntityCoords(ped)
-        while IsPedJumping(ped) do
-            Citizen.Wait(0)
-            if IsPedJumpingOutOfVehicle(ped) or IsPedRagdoll(ped) or IsPedInParachuteFreeFall(ped) or GetPedParachuteState(ped) > 0 then
-                break
+        if IsPedJumping(ped) then
+            -- Trigger server event with IsPlayerUsingSuperJump(source)
+            local startPos = GetEntityCoords(ped)
+
+            while IsPedJumping(ped) do
+                Wait(0)
+                if IsPedJumpingOutOfVehicle(ped) or IsPedRagdoll(ped) or IsPedInParachuteFreeFall(ped) or GetPedParachuteState(ped) > 0 then break end
+            end
+
+            local endPos = GetEntityCoords(ped)
+
+            local horizontalDist = Util.GetDistance(startPos.x, startPos.y, endPos.x, endPos.y)
+            if horizontalDist > 25.0 and not IsPedDeadOrDying(ped) then
+                TriggerServerEvent("icarus:417szjzm1goy", "Superjump [C2]", false, {jumpLength = horizontalDist})
+                return
             end
         end
-
-        local endPos = GetEntityCoords(ped)
-        local horizontalDist = Util.GetDistance(startPos.x, startPos.y, endPos.x, endPos.y)
-
-        if horizontalDist > 25.0 and not IsPedDeadOrDying(ped) then
-            TriggerServerEvent("icarus:417szjzm1goy", "Superjump [C2]", false, {jumpLength = horizontalDist})
-            return
-		end
-	end
+    end
 end)


### PR DESCRIPTION
local startPos = GetEntityCoords(ped) is now inside if jumping, removed (Citizen.), added commented suggestion where to trigger serverside check.

Don't know why you have thread to ensure that the ped variable is always up-to-date.