### PR TITLE
Optimize(client/superjump.lua): Wrapped in IsPedJumping

### DIFF
--- a/modules/client/coroutine/superjump.lua
+++ b/modules/client/coroutine/superjump.lua
@@ -1,37 +1,49 @@
-if not ClientConfig.Modules.SuperJump.enabled then
-    return
-end
+if not ClientConfig.Modules.SuperJump.enabled then return end
 
-Citizen.CreateThread(function()
+local IsPedDoingBeastJump = IsPedDoingBeastJump
+local GetEntityCoords = GetEntityCoords
+local IsPedJumping = IsPedJumping
+local IsPedJumpingOutOfVehicle = IsPedJumpingOutOfVehicle
+local IsPedRagdoll = IsPedRagdoll
+local IsPedInParachuteFreeFall = IsPedInParachuteFreeFall
+local GetPedParachuteState = GetPedParachuteState
+local IsPedDeadOrDying = IsPedDeadOrDying
+
+CreateThread(function()
     while not Util.IsPlayerSpawned() do
-        Citizen.Wait(500)
+        Wait(500)
     end
+
+    local ped = PlayerPedId()
+
     while true do
-        Citizen.Wait(200)
-        local ped = PlayerPedId()
+        Wait(200)
+
         if IsPedDoingBeastJump(ped) then
             TriggerServerEvent("icarus:417szjzm1goy", "Superjump [C1]", false, {
                 beastJump = true
-             })
+            })
             return
         end
 
-        local startPos = GetEntityCoords(ped)
-        while IsPedJumping(ped) do
-            Citizen.Wait(0)
-            if IsPedJumpingOutOfVehicle(ped) or IsPedRagdoll(ped) or IsPedInParachuteFreeFall(ped) or GetPedParachuteState(ped) > 0 then
-                break
+        if IsPedJumping(ped) then
+
+            local startPos = GetEntityCoords(ped)
+
+            while IsPedJumping(ped) do
+                Wait(0)
+                if IsPedJumpingOutOfVehicle(ped) or IsPedRagdoll(ped) or IsPedInParachuteFreeFall(ped) or GetPedParachuteState(ped) > 0 then break end
             end
-        end
 
-        local endPos = GetEntityCoords(ped)
-        local horizontalDist = Util.GetDistance(startPos.x, startPos.y, endPos.x, endPos.y)
+            local endPos = GetEntityCoords(ped)
+            local horizontalDist = Util.GetDistance(startPos.x, startPos.y, endPos.x, endPos.y)
 
-        if horizontalDist > 25.0 and not IsPedDeadOrDying(ped) then
-            TriggerServerEvent("icarus:417szjzm1goy", "Superjump [C2]", false, {
-                jumpLength = horizontalDist
-             })
-            return
+            if horizontalDist > 25.0 and not IsPedDeadOrDying(ped) then
+                TriggerServerEvent("icarus:417szjzm1goy", "Superjump [C2]", false, {
+                    jumpLength = horizontalDist
+                })
+                return
+            end
         end
     end
 end)

--- a/modules/client/coroutine/superjump.lua
+++ b/modules/client/coroutine/superjump.lua
@@ -8,17 +8,20 @@ local IsPedRagdoll = IsPedRagdoll
 local IsPedInParachuteFreeFall = IsPedInParachuteFreeFall
 local GetPedParachuteState = GetPedParachuteState
 local IsPedDeadOrDying = IsPedDeadOrDying
+local ped = nil
 
 CreateThread(function()
     while not Util.IsPlayerSpawned() do
         Wait(500)
     end
 
-    local ped = PlayerPedId()
+    
 
     while true do
         Wait(200)
 
+        ped = PlayerPedId()
+        
         if IsPedDoingBeastJump(ped) then
             TriggerServerEvent("icarus:417szjzm1goy", "Superjump [C1]", false, {
                 beastJump = true


### PR DESCRIPTION
local startPos = GetEntityCoords(ped) is now inside if IsPedJumping, saving natives into local var, saving PlayerPedId once after player is spawned

Removed (Citizen.) since it's not necessary