### PR TITLE
Fixed banning null

### DIFF
--- a/config/config_sv.lua
+++ b/config/config_sv.lua
@@ -10,6 +10,7 @@ ServerConfig.DiscordWebhook = ""
 
 -- Add your own ban logic here.
 function ServerConfig.BanPlayer(source, reason)
+    if GetPlayerPed(source) == 0 then return end   -- Player does not exist anymore, abort...
     TriggerEvent("EasyAdmin:banPlayer", source, "Cheating (" .. reason .. ")", 1044463300) -- EasyAdmin for the sake of simplicity.
 end
 


### PR DESCRIPTION
Sometimes heartbeat spoof gets trigger if the player connection dropped, but they are still in game 

https://github.com/EinS4ckZwiebeln/IcarusAdvancedAnticheat/blob/d06e6ac7021df4f39f9d894aba5d4a628edb4fa9/core/server/heartbeat.js#L19
This will kick them,

and after that :
https://github.com/EinS4ckZwiebeln/IcarusAdvancedAnticheat/blob/d06e6ac7021df4f39f9d894aba5d4a628edb4fa9/core/server/heartbeat.js#L31
This one , will try to ban them!
And because there are no player currently to ban, it can cause some issues (like in my case, database filled with null data).

This fix is more of a workaround, but it works so... 🤷 