### PR TITLE
feat: enable node v22

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ end
 
 | FXServer | OneSync  | Screenshot-basic                                          |
 | -------- | -------- | --------------------------------------------------------- |
-| 12911+   | Required | [Optional](https://github.com/citizenfx/screenshot-basic) |
+| 12913+   | Required | [Optional](https://github.com/citizenfx/screenshot-basic) |
 
 ### Documentation
 

--- a/build/build.js
+++ b/build/build.js
@@ -8,7 +8,7 @@ esbuild
 		bundle: true,
 		packages: "bundle",
 		platform: "node",
-		target: "node16.9.1",
+		target: "node22",
 		minifySyntax: true,
 		minifyWhitespace: true,
 	})

--- a/build/watch.js
+++ b/build/watch.js
@@ -10,7 +10,7 @@ const build = async () => {
 			sourcemap: true,
 			packages: "bundle",
 			platform: "node",
-			target: "node16.9.1",
+			target: "node22",
 		});
 		await ctx.watch();
 	} catch (error) {

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,6 +4,7 @@ game "gta5"
 
 author "EinS4ckZwiebeln"
 description "Lightweight and modular server-side anticheat script."
+node_version '22'
 version "2.1.3"
 
 lua54 "yes"
@@ -18,6 +19,6 @@ server_script {
 }
 
 dependencies {
-    "/server:12911",
+    "/server:12913",
     "/onesync"
 }


### PR DESCRIPTION
FXServer Artifacts version 12913 enables node 22, which provides numerous performance benefits. 12913 while unstable for node v22, still is the bare minimum with the current most stable being 13227.